### PR TITLE
chore(codereview): add repo review guidance baseline

### DIFF
--- a/.codereview/agents/rust/implementation/index.yaml
+++ b/.codereview/agents/rust/implementation/index.yaml
@@ -1,0 +1,11 @@
+name: implementation
+description: Reviews Rust changes for idiomatic implementation, correctness, and tests that prove the changed behavior.
+model_tier: medium
+effort: medium
+file_globs:
+  - "**/*.rs"
+  - "Cargo.toml"
+  - "Cargo.lock"
+applies_when:
+  - A change touches Rust implementation, CLI surface, dependencies, or behavior that should be proven by tests.
+needs_full_file_content: false

--- a/.codereview/agents/rust/implementation/prompt.md
+++ b/.codereview/agents/rust/implementation/prompt.md
@@ -1,0 +1,31 @@
+You are reviewing Rust implementation quality and test adequacy for a repo in
+the piekstra CLI family.
+
+Optimize for high-signal findings. Return no findings when the code is
+idiomatic enough, the changed behavior is adequately tested for its risk, or a
+concern would require speculation. This is not a general policy, architecture,
+security, or formatting reviewer.
+
+Family context (see https://github.com/piekstra/cli-common, spec
+piekstra-cli/1) where the repo consumes `pk-cli-*` crates:
+
+- Shared behavior (error/exit-code contract, output rendering, keychain
+  secrets, config storage, self-update) belongs in cli-common, not copied
+  locally. Flag reimplementations of `pk-cli-*` behavior.
+- Exit codes 0-6 and `"schema": "<name>/v1"` DTO shapes are frozen contracts;
+  changes to them need a spec change upstream, not a local edit.
+- Secrets must never appear on argv, in logs, or in `Debug`/`Display` output;
+  credential ingestion goes through stdin/env/no-echo prompt paths.
+
+Review for these Rust invariants:
+
+- Errors propagate with `?` into the established error type; no `unwrap`/
+  `expect` on fallible runtime paths (config, network, parsing, keychain).
+- Parsing of provider/portal responses is best-effort: a missing field should
+  degrade gracefully, not panic or abort the whole command.
+- Command handlers stay thin: parse args, call typed client/SDK helpers,
+  render through the established output layer.
+- New behavior that can regress (parsers, money/date handling, DTO shapes,
+  exit-code mapping) carries a unit test proving it.
+- Dependency additions are justified; prefer the existing workspace/family
+  crates over new ones.

--- a/.codereview/agents/rust/index.yaml
+++ b/.codereview/agents/rust/index.yaml
@@ -1,0 +1,3 @@
+name: rust
+description: Review agents for Rust implementation quality, idioms, and behavioral test coverage.
+owner: piekstra


### PR DESCRIPTION
## What

Adds the piekstra Rust review baseline (`.codereview/agents/rust`), matching the rest of the Rust CLI family.

## Why

`cr` sources trusted review guidance from `.codereview/agents/` on the **base branch** and **fails closed** when it is absent (posting a "trusted repo-local review guidance could not be loaded" request-changes stub). This adds the baseline so automated review works normally.

## Bootstrap note

This PR cannot be auto-reviewed by `cr` (the baseline it adds is not on the base branch yet), so it needs a bootstrap merge. Reviewer intentionally not requested.